### PR TITLE
Persist generated report outputs in Streamlit

### DIFF
--- a/core/visual_report_manager.py
+++ b/core/visual_report_manager.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+from .logger import LogManager
+
+__all__ = ["VisualPlotSpec", "VisualReportManager"]
+
+log = LogManager("visual_report").get_logger()
+
+
+@dataclass
+class VisualPlotSpec:
+    """Specifica per un singolo grafico nel report visivo."""
+
+    y_column: str
+    title: Optional[str] = None
+    x_label: Optional[str] = None
+    y_label: Optional[str] = None
+
+
+class VisualReportManager:
+    """Crea report visivi composti da massimo 4 grafici impilati."""
+
+    def __init__(self, output_dir: Optional[Path] = None) -> None:
+        project_root = Path(__file__).resolve().parents[1]
+        base_dir = output_dir or (project_root / "outputs" / "visual_reports")
+        base_dir.mkdir(parents=True, exist_ok=True)
+        self.output_dir = base_dir
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _sanitize_filename(name: str) -> str:
+        import re
+
+        sanitized = re.sub(r"[^A-Za-z0-9._-]+", "_", name).strip("_._")
+        return sanitized or "visual_report"
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _prepare_xy(
+        df: pd.DataFrame,
+        y_column: str,
+        x_column: Optional[str],
+    ) -> tuple[pd.Series, pd.Series]:
+        if y_column not in df.columns:
+            raise ValueError(f"Colonna Y '{y_column}' non trovata nel DataFrame.")
+
+        y_series = pd.to_numeric(df[y_column], errors="coerce")
+
+        x_series: Optional[pd.Series] = None
+        if x_column and x_column in df.columns:
+            raw_x = df[x_column]
+            if pd.api.types.is_datetime64_any_dtype(raw_x) or pd.api.types.is_timedelta64_dtype(raw_x):
+                x_series = pd.to_datetime(raw_x, errors="coerce")
+            else:
+                x_numeric = pd.to_numeric(raw_x, errors="coerce")
+                if x_numeric.notna().mean() >= 0.5:
+                    x_series = x_numeric
+                else:
+                    x_dt = pd.to_datetime(raw_x, errors="coerce")
+                    if x_dt.notna().any():
+                        x_series = x_dt
+            if x_series is None:
+                # fallback: uso stringhe per conservare informazione
+                x_series = raw_x.astype(str)
+        else:
+            x_series = pd.Series(df.index, name=x_column or "index")
+
+        paired = pd.DataFrame({"x": x_series, "y": y_series}).dropna()
+        if paired.empty:
+            raise ValueError(
+                f"Colonna '{y_column}' non contiene dati numerici validi in combinazione con X selezionata."
+            )
+        return paired["x"], paired["y"]
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _build_figure(
+        df: pd.DataFrame,
+        specs: Sequence[VisualPlotSpec],
+        x_column: Optional[str],
+        report_title: Optional[str],
+        template: str,
+        height_per_plot: int,
+        show_legend: bool,
+    ) -> go.Figure:
+        rows = len(specs)
+        subplot_titles = [spec.title or spec.y_column for spec in specs]
+        fig = make_subplots(rows=rows, cols=1, shared_xaxes=False, vertical_spacing=0.08, subplot_titles=subplot_titles)
+
+        for idx, spec in enumerate(specs, start=1):
+            x_series, y_series = VisualReportManager._prepare_xy(df, spec.y_column, x_column)
+            trace_name = spec.title or spec.y_column
+            fig.add_trace(
+                go.Scatter(x=x_series, y=y_series, mode="lines", name=trace_name),
+                row=idx,
+                col=1,
+            )
+            fig.update_yaxes(title_text=spec.y_label or spec.y_column, row=idx, col=1)
+            default_x_label = x_column if x_column else "Index"
+            fig.update_xaxes(title_text=spec.x_label or default_x_label, row=idx, col=1)
+
+        height = max(1, rows) * height_per_plot
+        fig.update_layout(
+            title=report_title,
+            template=template,
+            showlegend=show_legend,
+            height=height,
+            margin=dict(l=70, r=40, t=80 if report_title else 50, b=50),
+        )
+        if show_legend:
+            fig.update_layout(legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1))
+        return fig
+
+    # ------------------------------------------------------------------
+    def generate_report(
+        self,
+        df: pd.DataFrame,
+        specs: Iterable[VisualPlotSpec],
+        x_column: Optional[str] = None,
+        title: Optional[str] = None,
+        base_name: Optional[str] = None,
+        file_format: str = "png",
+        height_per_plot: int = 420,
+        template: str = "plotly_white",
+        show_legend: bool = False,
+        scale: float = 2.0,
+    ) -> dict:
+        """Genera il report visivo e lo salva come PNG o PDF.
+
+        Restituisce un dict con figure Plotly, percorso del file e contenuto binario.
+        """
+
+        spec_list: List[VisualPlotSpec] = [s for s in specs]
+        if not spec_list:
+            raise ValueError("Specificare almeno un grafico per il report visivo.")
+        if len(spec_list) > 4:
+            raise ValueError("Il report visivo supporta al massimo 4 grafici.")
+
+        fmt = (file_format or "png").strip().lower()
+        if fmt not in {"png", "pdf"}:
+            raise ValueError("Formato non supportato. Usare 'png' oppure 'pdf'.")
+
+        fig = self._build_figure(
+            df=df,
+            specs=spec_list,
+            x_column=x_column,
+            report_title=title,
+            template=template,
+            height_per_plot=height_per_plot,
+            show_legend=show_legend,
+        )
+
+        base = base_name.strip() if base_name else ""
+        if not base:
+            base = f"visual_report_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        filename = f"{self._sanitize_filename(base)}.{fmt}"
+        output_path = self.output_dir / filename
+
+        width = 1280
+        height = height_per_plot * len(spec_list)
+
+        try:
+            image_bytes = fig.to_image(format=fmt, width=width, height=height, scale=scale)
+        except Exception as exc:
+            raise RuntimeError(
+                "Impossibile esportare il report visivo. Assicurarsi che il pacchetto 'kaleido' sia installato."
+            ) from exc
+
+        output_path.write_bytes(image_bytes)
+        log.info("Report visivo salvato in %s", output_path)
+
+        return {"figure": fig, "path": output_path, "bytes": image_bytes, "format": fmt}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pandas>=2.2
 numpy>=1.26
 plotly>=5.22
+kaleido>=0.2.1
 textual>=0.89,<0.91
 rich>=13.9
 streamlit>=1.32

--- a/web_app.py
+++ b/web_app.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -11,6 +11,7 @@ import streamlit as st
 from core.analyzer import analyze_csv
 from core.loader import load_csv
 from core.report_manager import ReportManager
+from core.visual_report_manager import VisualPlotSpec, VisualReportManager
 from core.signal_tools import (
     FilterSpec,
     FFTSpec,
@@ -190,6 +191,22 @@ def render_header():
 
 
 # ---------------------- UI principale ---------------------- #
+def _reset_generated_reports_marker(current_file: Optional[Any]) -> None:
+    """Reset session-state outputs when the uploaded file changes."""
+
+    file_id = None
+    if current_file is not None:
+        file_id = (current_file.name, getattr(current_file, "size", None))
+
+    last_id = st.session_state.get("_last_uploaded_file_id")
+    if last_id != file_id:
+        st.session_state["_last_uploaded_file_id"] = file_id
+        st.session_state.pop("_generated_report", None)
+        st.session_state.pop("_generated_report_error", None)
+        st.session_state.pop("_generated_visual_report", None)
+        st.session_state.pop("_generated_visual_report_error", None)
+
+
 def main():
     st.set_page_config(page_title="Analizzatore CSV — Web", layout="wide")
     render_header()
@@ -197,6 +214,7 @@ def main():
     st.caption("Upload CSV → seleziona X/Y → limiti assi → Advanced (fs/filtri/FFT) → report")
 
     upload = st.file_uploader("Carica un file CSV", type=["csv"])
+    _reset_generated_reports_marker(upload)
     if not upload:
         st.info("Carica un file per iniziare.")
         return
@@ -523,11 +541,112 @@ def main():
     with col_r2:
         if st.button("Genera report"):
             try:
-                out = ReportManager().generate_report(df, x_name, y_cols, formats=fmt, base_name=base_name or None)
-                st.success("Report generato.")
-                st.json({k: str(v) if v else None for k, v in out.items()})
+                out = ReportManager().generate_report(
+                    df, x_name, y_cols, formats=fmt, base_name=base_name or None
+                )
+                st.session_state["_generated_report"] = out
+                st.session_state.pop("_generated_report_error", None)
             except Exception as e:
-                st.error(f"Generazione report fallita: {e}")
+                st.session_state.pop("_generated_report", None)
+                st.session_state["_generated_report_error"] = str(e)
+
+    report_error = st.session_state.get("_generated_report_error")
+    if report_error:
+        st.error(f"Generazione report fallita: {report_error}")
+    generated_report = st.session_state.get("_generated_report")
+    if generated_report:
+        st.success("Report generato.")
+        st.json({k: str(v) if v else None for k, v in generated_report.items()})
+
+    st.divider()
+    st.subheader("Report visivo dei grafici")
+    st.caption("Scegli fino a 4 serie per creare un'immagine o un PDF con i grafici in cascata.")
+
+    visual_selection = st.multiselect(
+        "Serie da includere (max 4)",
+        options=y_cols,
+        default=y_cols[: min(4, len(y_cols))],
+        max_selections=4,
+        help="Le serie devono essere numeriche; eventuali NaN verranno ignorati.",
+    )
+
+    visual_specs: List[VisualPlotSpec] = []
+    default_x_label = x_name if x_name else "Index"
+    for idx, yname in enumerate(visual_selection):
+        with st.expander(f"Grafico {idx + 1} — {yname}", expanded=False):
+            plot_title = st.text_input(
+                "Titolo grafico",
+                value=yname,
+                key=f"vis_report_title_{idx}_{yname}",
+            )
+            x_label = st.text_input(
+                "Titolo asse X",
+                value=default_x_label,
+                key=f"vis_report_xlabel_{idx}_{yname}",
+            )
+            y_label = st.text_input(
+                "Titolo asse Y",
+                value=yname,
+                key=f"vis_report_ylabel_{idx}_{yname}",
+            )
+        visual_specs.append(
+            VisualPlotSpec(
+                y_column=yname,
+                title=plot_title or None,
+                x_label=x_label or None,
+                y_label=y_label or None,
+            )
+        )
+
+    col_vis1, col_vis2 = st.columns([2, 1])
+    with col_vis1:
+        visual_title = st.text_input("Titolo report visivo", key="vis_report_main_title")
+        visual_base = st.text_input("Nome file (opzionale)", placeholder="es. report_visivo", key="vis_report_base")
+    with col_vis2:
+        visual_format = st.radio("Formato", ["png", "pdf"], horizontal=True, key="vis_report_format")
+        visual_show_legend = st.checkbox("Mostra legenda", value=False, key="vis_report_legend")
+
+    btn_col1, btn_col2, btn_col3 = st.columns([1, 1, 2])
+    with btn_col2:
+        generate_visual = st.button("Genera report visivo", use_container_width=True)
+
+    if generate_visual:
+        if not visual_specs:
+            st.warning("Seleziona almeno una serie per il report visivo.")
+        else:
+            try:
+                with st.spinner("Generazione report visivo..."):
+                    manager = VisualReportManager()
+                    result = manager.generate_report(
+                        df=df,
+                        specs=visual_specs,
+                        x_column=x_name,
+                        title=visual_title or None,
+                        base_name=visual_base or None,
+                        file_format=visual_format,
+                        show_legend=visual_show_legend,
+                    )
+                st.session_state["_generated_visual_report"] = result
+                st.session_state.pop("_generated_visual_report_error", None)
+            except Exception as e:
+                st.session_state.pop("_generated_visual_report", None)
+                st.session_state["_generated_visual_report_error"] = str(e)
+
+    visual_error = st.session_state.get("_generated_visual_report_error")
+    if visual_error:
+        st.error(f"Generazione report visivo fallita: {visual_error}")
+    visual_result = st.session_state.get("_generated_visual_report")
+    if visual_result:
+        st.success(f"Report visivo salvato in {visual_result['path']}")
+        mime = "application/pdf" if visual_result["format"] == "pdf" else "image/png"
+        st.download_button(
+            "Scarica report",
+            data=visual_result["bytes"],
+            file_name=visual_result["path"].name,
+            mime=mime,
+        )
+        if visual_result["format"] == "png":
+            st.image(visual_result["bytes"], caption="Anteprima report visivo", use_column_width=True)
 
     st.divider()
     with st.expander("ℹ️ Info rilevate (clicca per espandere)", expanded=False):


### PR DESCRIPTION
## Summary
- reset cached outputs when the uploaded CSV changes to avoid stale report data
- persist generated report and visual report results in Streamlit session state so downloads remain visible after reruns
- surface stored success/error messages and downloads after button-triggered reruns

## Testing
- python -m compileall core ui web_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e7714b71188329911c6247c54f5bd1